### PR TITLE
Add end option to consumer

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ Read messages starting from a UNIX timestamp (in milliseconds) and print their v
 $ kafkadog consume -b mybroker:9092 -s 1591747200000 my_topic
 ```
 
+Read messages starting at the oldest available offset and ending at a date (in UTC timezone) :
+
+```console
+$ kafkadog consume -b mybroker:9092 -s oldest -e '2020-06-10 00:00:00' my_topic
+```
+
 ### Producer
 
 Produce one message :
@@ -81,6 +87,13 @@ $ kafkadog produce -b mybroker:9092 -f messages.txt my_topic
 ## Detailed usage
 
 Run `kafkadog -h` for detailed usage and help.
+
+## TODO
+
+* √ Improve start offset/time selection for consumer.
+* √ Add an "quit" option to stop consuming when the log head is reached.
+* Fix "key delimiter" option -> "key-delimiter"
+* Fix ineffectual assignments (https://goreportcard.com/report/github.com/maximepeschard/kafkadog#ineffassign)
 
 ## Credits
 

--- a/client/consumer.go
+++ b/client/consumer.go
@@ -2,28 +2,58 @@ package client
 
 import (
 	"context"
-	"fmt"
-	"sync"
+	"errors"
+	"time"
 
 	"github.com/Shopify/sarama"
+	"golang.org/x/sync/errgroup"
 )
 
 // A ConsumerRequest specifies what to consume and how.
 type ConsumerRequest struct {
-	Topic     string
-	StartTime int64
-	Quit      bool
+	topic     string
+	start     int64
+	end       int64
+	startTime *time.Time
+	endTime   *time.Time
 }
 
-// NewConsumerRequest returns a ConsumerRequest.
-func NewConsumerRequest(topic string, startTime int64, quit bool) ConsumerRequest {
-	cr := ConsumerRequest{
-		Topic:     topic,
-		StartTime: startTime,
-		Quit:      quit,
+// NewConsumerRequest creates a valid ConsumerRequest.
+func NewConsumerRequest(topic string, start int64, end int64) (ConsumerRequest, error) {
+	cr := ConsumerRequest{topic: topic}
+
+	now := time.Now()
+	var startTime, endTime *time.Time
+
+	if start == StartNow {
+		startTime = &now
+		cr.start = sarama.OffsetNewest
+	} else if start == StartOldest {
+		cr.start = sarama.OffsetOldest
+	} else {
+		t := time.Unix(start/1000, (start%1000)*1000000)
+		startTime = &t
+		cr.start = start
 	}
 
-	return cr
+	if end == EndNow {
+		endTime = &now
+	} else if end != EndNever {
+		t := time.Unix(end/1000, (end%1000)*1000000)
+		endTime = &t
+	}
+	cr.end = end
+
+	if end != EndNever && start != StartOldest {
+		if endTime.Before(*startTime) || endTime.Equal(*startTime) {
+			return cr, errors.New("invalid start / end combination")
+		}
+	}
+
+	cr.startTime = startTime
+	cr.endTime = endTime
+
+	return cr, nil
 }
 
 // Consumer is a high level API for a Kafka consumer.
@@ -50,59 +80,71 @@ func NewConsumer(broker string) (Consumer, error) {
 	return Consumer{broker, client, consumer}, nil
 }
 
-// Consume reads messages from topic and sends them to the given chan until ctx is done.
-func (c Consumer) Consume(ctx context.Context, topic string, startTime int64, messages chan<- Message) error {
-	partitions, err := c.consumer.Partitions(topic)
-	if err != nil {
-		return err
-	}
-
-	var wg sync.WaitGroup
-
-	// We need to read separately each partition of the topic.
-	for _, p := range partitions {
-		startOffset, err := c.client.GetOffset(topic, p, startTime)
-		if err != nil {
-			return err
-		}
-
-		pc, err := c.consumer.ConsumePartition(topic, p, startOffset)
-		if err != nil {
-			fmt.Println(err)
-			return err
-		}
-
-		go func(pc sarama.PartitionConsumer) {
-			<-ctx.Done()
-			pc.AsyncClose()
-		}(pc)
-
-		wg.Add(1)
-		go func(pc sarama.PartitionConsumer) {
-			defer wg.Done()
-
-			for m := range pc.Messages() {
-				message := Message{
-					Topic:     m.Topic,
-					Partition: m.Partition,
-					Offset:    m.Offset,
-					Timestamp: m.Timestamp,
-					Key:       string(m.Key),
-					Value:     string(m.Value),
-				}
-				messages <- message
-			}
-		}(pc)
-	}
-
-	wg.Wait()
-	return nil
-}
-
 // Close shuts the consumer down.
 func (c Consumer) Close() error {
 	err := c.consumer.Close()
 	err = c.client.Close()
 
 	return err
+}
+
+// Consume reads messages matching the ConsumerRequest and sends them to the given chan until ctx is done.
+func (c Consumer) Consume(ctx context.Context, req ConsumerRequest, messages chan<- Message) error {
+	partitions, err := c.consumer.Partitions(req.topic)
+	if err != nil {
+		return err
+	}
+
+	g, ctx := errgroup.WithContext(ctx)
+
+	// We need to read separately each partition of the topic.
+	for _, p := range partitions {
+		partReq := partitionConsumerRequest{req, p}
+		g.Go(func() error { return c.consumePartition(ctx, partReq, messages) })
+	}
+
+	return g.Wait()
+}
+
+type partitionConsumerRequest struct {
+	ConsumerRequest
+
+	partition int32
+}
+
+func (c Consumer) consumePartition(ctx context.Context, req partitionConsumerRequest, messages chan<- Message) error {
+	startOffset, err := c.client.GetOffset(req.topic, req.partition, req.start)
+	if err != nil {
+		return err
+	}
+
+	pc, err := c.consumer.ConsumePartition(req.topic, req.partition, startOffset)
+	if err != nil {
+		return err
+	}
+
+	go func() {
+		<-ctx.Done()
+		pc.AsyncClose()
+	}()
+
+	for m := range pc.Messages() {
+		message := Message{
+			Topic:     m.Topic,
+			Partition: m.Partition,
+			Offset:    m.Offset,
+			Timestamp: m.Timestamp,
+			Key:       string(m.Key),
+			Value:     string(m.Value),
+		}
+
+		if req.endTime != nil && (m.Timestamp.After(*req.endTime) || pc.HighWaterMarkOffset() == m.Offset+1) {
+			pc.AsyncClose()
+			break
+		}
+
+		messages <- message
+	}
+
+	return nil
 }

--- a/client/consumer.go
+++ b/client/consumer.go
@@ -8,6 +8,24 @@ import (
 	"github.com/Shopify/sarama"
 )
 
+// A ConsumerRequest specifies what to consume and how.
+type ConsumerRequest struct {
+	Topic     string
+	StartTime int64
+	Quit      bool
+}
+
+// NewConsumerRequest returns a ConsumerRequest.
+func NewConsumerRequest(topic string, startTime int64, quit bool) ConsumerRequest {
+	cr := ConsumerRequest{
+		Topic:     topic,
+		StartTime: startTime,
+		Quit:      quit,
+	}
+
+	return cr
+}
+
 // Consumer is a high level API for a Kafka consumer.
 type Consumer struct {
 	broker   string

--- a/client/formatter.go
+++ b/client/formatter.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // Valid format string placeholders.
@@ -19,14 +20,13 @@ const (
 // FormatterHelp returns a message describing format tokens.
 func FormatterHelp() string {
 	var b strings.Builder
-	fmt.Fprint(&b, "* available format tokens :\n")
-	fmt.Fprintf(&b, "%s : topic\n", TopicPlaceholder)
-	fmt.Fprintf(&b, "%s : partition\n", PartitionPlaceholder)
-	fmt.Fprintf(&b, "%s : offset\n", OffsetPlaceholder)
-	fmt.Fprintf(&b, "%s : timestamp\n", TimestampPlaceholder)
-	fmt.Fprintf(&b, "%s : message key\n", KeyPlaceholder)
-	fmt.Fprintf(&b, "%s : message value\n", ValuePlaceholder)
-	fmt.Fprint(&b, "* example format string : 'received %v from %t'")
+	fmt.Fprintf(&b, "* %s : topic\n", TopicPlaceholder)
+	fmt.Fprintf(&b, "* %s : partition\n", PartitionPlaceholder)
+	fmt.Fprintf(&b, "* %s : offset\n", OffsetPlaceholder)
+	fmt.Fprintf(&b, "* %s : timestamp (epoch in milliseconds)\n", TimestampPlaceholder)
+	fmt.Fprintf(&b, "* %s : message key\n", KeyPlaceholder)
+	fmt.Fprintf(&b, "* %s : message value\n", ValuePlaceholder)
+	fmt.Fprint(&b, "(example format string : 'received %v from %t')")
 	return b.String()
 }
 
@@ -46,7 +46,7 @@ func (f Formatter) Format(m Message) string {
 		TopicPlaceholder, m.Topic,
 		PartitionPlaceholder, strconv.FormatInt(int64(m.Partition), 10),
 		OffsetPlaceholder, strconv.FormatInt(m.Offset, 10),
-		TimestampPlaceholder, strconv.FormatInt(m.Timestamp.Unix(), 10),
+		TimestampPlaceholder, strconv.FormatInt(m.Timestamp.UnixNano()/int64(time.Millisecond), 10),
 		KeyPlaceholder, string(m.Key),
 		ValuePlaceholder, string(m.Value),
 	)

--- a/client/offset.go
+++ b/client/offset.go
@@ -5,20 +5,25 @@ import (
 	"strconv"
 	"strings"
 	"time"
-
-	"github.com/Shopify/sarama"
 )
 
 const dateTimeLayout string = "2006-01-02 15:04:05"
 
+// Special time values
+const (
+	StartOldest int64 = -1
+	StartNow    int64 = -2
+	EndNow      int64 = -3
+	EndNever    int64 = -4
+)
+
 // StartHelp returns a message describing valid start values.
 func StartHelp() string {
 	var b strings.Builder
-	fmt.Fprint(&b, "* available start values :\n")
-	fmt.Fprintf(&b, "newest : start at log head offset\n")
-	fmt.Fprintf(&b, "oldest : start at the oldest available offset\n")
-	fmt.Fprintf(&b, "YYYY-mm-dd HH:MM:SS : start at this date (UTC)\n")
-	fmt.Fprintf(&b, "<epoch in milliseconds> : start at this epoch")
+	fmt.Fprintf(&b, "* now : start from messages more recent than now\n")
+	fmt.Fprintf(&b, "* oldest : start at the oldest available offset\n")
+	fmt.Fprintf(&b, "* YYYY-mm-dd HH:MM:SS : start at this date (UTC)\n")
+	fmt.Fprintf(&b, "* <epoch in milliseconds> : start at this epoch")
 	return b.String()
 }
 
@@ -26,20 +31,64 @@ func StartHelp() string {
 func ParseStart(s string) (int64, error) {
 	switch s {
 	case "oldest":
-		return sarama.OffsetOldest, nil
-	case "newest":
-		return sarama.OffsetNewest, nil
+		return StartOldest, nil
+	case "now":
+		return StartNow, nil
 	default:
-		t, err := time.Parse(dateTimeLayout, s)
+		start, err := parseDateTime(s)
 		if err == nil {
-			return t.UnixNano() / int64(time.Millisecond), nil
+			return start, nil
 		}
 
-		e, err := strconv.ParseInt(s, 10, 64)
+		start, err = parseEpoch(s)
 		if err == nil {
-			return e, nil
+			return start, nil
 		}
 
-		return 0, fmt.Errorf("invalid start offset %q", s)
+		return 0, fmt.Errorf("invalid start time %q", s)
 	}
+}
+
+// EndHelp returns a message describing valid end values.
+func EndHelp() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "* now : end when messages are more recent than now\n")
+	fmt.Fprintf(&b, "* YYYY-mm-dd HH:MM:SS : end at this date (UTC)\n")
+	fmt.Fprintf(&b, "* <epoch in milliseconds> : end at this epoch")
+	return b.String()
+}
+
+// ParseEnd returns an end time parsed from s.
+func ParseEnd(s string) (int64, error) {
+	switch s {
+	case "now":
+		return EndNow, nil
+	case "never":
+		return EndNever, nil
+	default:
+		end, err := parseDateTime(s)
+		if err == nil {
+			return end, nil
+		}
+
+		end, err = parseEpoch(s)
+		if err == nil {
+			return end, nil
+		}
+
+		return 0, fmt.Errorf("invalid end time %q", s)
+	}
+}
+
+func parseDateTime(s string) (int64, error) {
+	t, err := time.Parse(dateTimeLayout, s)
+	if err != nil {
+		return 0, err
+	}
+
+	return t.UnixNano() / int64(time.Millisecond), nil
+}
+
+func parseEpoch(s string) (int64, error) {
+	return strconv.ParseInt(s, 10, 64)
 }

--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.14
 require (
 	github.com/Shopify/sarama v1.26.4
 	github.com/spf13/cobra v1.0.0
+	golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4
 )

--- a/go.sum
+++ b/go.sum
@@ -146,6 +146,7 @@ golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4 h1:YUO/7uOKsKeq9UokNS62b8FYywz3ker1l1vDZRCRefw=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
Adds a `-e` / `--end` option to the consumer API, to allow reading messages up to a certain timestamp and exit. This option has a similar usage to that of the `-s` / `--start` option.